### PR TITLE
only update the window surface once, not per pixel

### DIFF
--- a/graphics.c
+++ b/graphics.c
@@ -63,8 +63,10 @@ graphics_init(void)
 void graphics_draw(void)
 {
     uint32_t color = PIXEL_BLACK;
-        for (int y_g = 0; y_g < SCREEN_HEIGHT; y_g++) {
-            for (int x_g = 0; x_g < SCREEN_WIDTH; x_g++) {
+        for (int y_g = 0; y_g < SCREEN_HEIGHT; y_g++)
+        {
+            for (int x_g = 0; x_g < SCREEN_WIDTH; x_g++)
+            {
                 pixel.x = x_g * 10;
                 pixel.y = y_g * 10;
                 if(gfx[y_g][x_g] == 1)
@@ -75,15 +77,10 @@ void graphics_draw(void)
                 {
                     color = PIXEL_BLACK;
                 }
-               // printf("%d ",gfx[y_g][x_g]);
                 SDL_FillRect(screenSurface, &pixel, color);
-                SDL_UpdateWindowSurface(window);
             }
-            //printf("\n");
         }
-
-
-
+    SDL_UpdateWindowSurface(window);
 }
 
 void


### PR DESCRIPTION
This is the cause of the speed issue.

Now you just need to add timing so that you only update at 60hz.

You can do the easy way of using sdl2 renderer instead and enabling vsync. However this would mean that your opcode execute would run at 60hz, chip8 tends to run at 500-1000hz. A simple way around this is to just wrap that in a for loop. So for a 600hz cpu you would for have the loop run 10 times (10 * 60 = 600). If you would like me to send you a quick implementation of that then let me know.

Lastly, yeah there is a bug with your opcodes somewhere, i'll try and find it.